### PR TITLE
added sources target for koji build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: build check install dist srpm rpm pypi clean
+.PHONY: build check install dist sources srpm rpm pypi clean
 
-NAME = object-validator
+NAME     = object-validator
 RPM_NAME := python-$(NAME)
-PYTHON := python
+PYTHON   := python
+VERSION  := 0.1.6
 
 build:
 	$(PYTHON) setup.py build
@@ -16,6 +17,10 @@ install:
 dist:
 	$(PYTHON) setup.py sdist
 	mv dist/$(NAME)-*.tar.gz .
+
+sources:
+	@git archive --format=tar --prefix="$(NAME)-$(VERSION)/" \
+		$(shell git rev-parse --verify HEAD) | gzip > $(NAME)-$(VERSION).tar.gz
 
 srpm: dist
 	rpmbuild -bs --define "_sourcedir $(CURDIR)" $(RPM_NAME).spec

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     with open("README") as readme:
         setup(
             name = "object-validator",
-            version = "0.1.5",
+            version = "0.1.6",
 
             description = readme.readline().strip(),
             long_description = readme.read().strip() or None,


### PR DESCRIPTION
- Added separate build target `sources`, because koji build system can't install BuildRequires, when building SRPM from SCM -> no ability to use python-setuptools in `make sources`.
- Bumped minor version in `setup.py`.