### PR TITLE
Add python3 package build for EPEL

### DIFF
--- a/python-object-validator.spec
+++ b/python-object-validator.spec
@@ -144,7 +144,7 @@ make PYTHON=%{__python3_other} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 
 
 %changelog
-* Wed Jan 09 2019 Dmitry Konishchev <konishchev@gmail.com> - 0.2.0-2
+* Wed Jan 09 2019 Mikhail Ushanov <gm.mephisto@gmail.com> - 0.2.0-2
 - Add python3 package build for EPEL
 
 * Thu Jan 11 2018 Dmitry Konishchev <konishchev@gmail.com> - 0.2.0-1

--- a/python-object-validator.spec
+++ b/python-object-validator.spec
@@ -34,7 +34,7 @@ validate arbitrary Python objects or to support custom validation rules.}
 
 Name:    python-%project_name
 Version: 0.2.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Python object validation module
 
 Group:   Development/Libraries
@@ -144,6 +144,9 @@ make PYTHON=%{__python3_other} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 
 
 %changelog
+* Wed Jan 09 2019 Dmitry Konishchev <konishchev@gmail.com> - 0.2.0-2
+- Add python3 package build for EPEL
+
 * Thu Jan 11 2018 Dmitry Konishchev <konishchev@gmail.com> - 0.2.0-1
 - Base class for number types with min/max validators
 - flake8 linting and tox tests automation

--- a/python-object-validator.spec
+++ b/python-object-validator.spec
@@ -1,22 +1,36 @@
-%if 0%{?fedora} > 12 || 0%{?rhel} > 7
+%if 0%{?fedora} > 12 || 0%{?epel} >= 6
 %bcond_without python3
 %else
 %bcond_with python3
 %endif
 
-%if 0%{?rhel} && 0%{?rhel} <= 6
+%if 0%{?epel} >= 7
+%bcond_without python3_other
+%endif
+
+%if 0%{?rhel} <= 6
 %{!?__python2: %global __python2 /usr/bin/python2}
 %{!?python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %endif
 %if 0%{with python3}
 %{!?__python3: %global __python3 /usr/bin/python3}
 %{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?python3_pkgversion: %global python3_pkgversion 3}
 %endif  # with python3
 
-%define project_name object-validator
+%global project_name object-validator
+%global project_description %{expand:
+This module is intended for validation of Python objects. For this time it's
+supposed to be used for validation of configuration files represented as JSON
+or for validation of JSON-PRC requests, but it can be easily extended to
+validate arbitrary Python objects or to support custom validation rules.}
 
-# Run tests
+# Temporarily disable tests for python3_other
+%if 0%{with python3_other}
+%bcond_with tests
+%else
 %bcond_without tests
+%endif
 
 Name:    python-%project_name
 Version: 0.2.0
@@ -28,41 +42,38 @@ License: GPLv3
 URL:     https://github.com/KonishchevDmitry/%project_name
 Source:  http://pypi.python.org/packages/source/o/%project_name/%project_name-%version.tar.gz
 
-Requires: python
-
 BuildArch:     noarch
 BuildRequires: make
 BuildRequires: python2-devel python-setuptools
-%if 0%{with python3}
-BuildRequires: python3-devel python3-setuptools
-%endif  # with python3
-
 %if 0%{with tests}
 BuildRequires: pytest >= 2.2.4
-%if 0%{with python3}
-BuildRequires: python3-pytest >= 2.2.4
-%endif  # with python3
 %endif  # with tests
 
-%description
-This module is intended for validation of Python objects. For this time it's
-supposed to be used for validation of configuration files represented as JSON
-or for validation of JSON-PRC requests, but it can be easily extended to
-validate arbitrary Python objects or to support custom validation rules.
+%description %{project_description}
 
 
 %if 0%{with python3}
-%package -n python3-%project_name
-Summary: Python object validation module
-
-Requires: python3
-
-%description -n python3-%project_name
-This module is intended for validation of Python objects. For this time it's
-supposed to be used for validation of configuration files represented as JSON
-or for validation of JSON-PRC requests, but it can be easily extended to
-validate arbitrary Python objects or to support custom validation rules.
+%package -n python%{python3_pkgversion}-%project_name
+Summary: %{summary}
+BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-setuptools
+%if 0%{with tests}
+BuildRequires: python%{python3_pkgversion}-pytest >= 2.2.4
+%endif  # with tests
+%description -n python%{python3_pkgversion}-%project_name %{project_description}
 %endif  # with python3
+
+
+%if 0%{with python3_other}
+%package -n python%{python3_other_pkgversion}-%project_name
+Summary: %{summary}
+BuildRequires: python%{python3_other_pkgversion}-devel
+BuildRequires: python%{python3_other_pkgversion}-setuptools
+%if 0%{with tests}
+BuildRequires: python%{python3_other_pkgversion}-pytest >= 2.2.4
+%endif  # with tests
+%description -n python%{python3_other_pkgversion}-%project_name %{project_description}
+%endif  # with python3_other
 
 
 %prep
@@ -74,6 +85,9 @@ make PYTHON=%{__python2}
 %if 0%{with python3}
 make PYTHON=%{__python3}
 %endif  # with python3
+%if 0%{with python3_other}
+make PYTHON=%{__python3_other}
+%endif  # with python3_other
 
 
 %check
@@ -82,6 +96,9 @@ make PYTHON=%{__python2} check
 %if 0%{with python3}
 make PYTHON=%{__python3} check
 %endif  # with python3
+%if 0%{with python3_other}
+make PYTHON=%{__python3_other} check
+%endif  # with python3_other
 %endif  # with tests
 
 
@@ -92,6 +109,9 @@ make PYTHON=%{__python2} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %if 0%{with python3}
 make PYTHON=%{__python3} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %endif  # with python3
+%if 0%{with python3_other}
+make PYTHON=%{__python3_other} INSTALL_FLAGS="-O1 --root '%buildroot'" install
+%endif  # with python3_other
 
 
 %files
@@ -101,13 +121,22 @@ make PYTHON=%{__python3} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %doc ChangeLog README INSTALL
 
 %if 0%{with python3}
-%files -n python3-%project_name
+%files -n python%{python3_pkgversion}-%project_name
 %defattr(-,root,root,-)
 %{python3_sitelib}/object_validator.py
 %{python3_sitelib}/__pycache__/object_validator.*.py*
 %{python3_sitelib}/object_validator-%{version}-*.egg-info
 %doc ChangeLog README INSTALL
 %endif  # with python3
+
+%if 0%{with python3_other}
+%files -n python%{python3_other_pkgversion}-%project_name
+%defattr(-,root,root,-)
+%{python3_other_sitelib}/object_validator.py
+%{python3_other_sitelib}/__pycache__/object_validator.*.py*
+%{python3_other_sitelib}/object_validator-%{version}-*.egg-info
+%doc ChangeLog README INSTALL
+%endif  # with python3_other
 
 
 %clean


### PR DESCRIPTION
* В EPEL6/7 появились две ветки `python3.X` версий - `python3` и `python3_other`. Добавлена поддержка сборки таких пакетов, при этом оставлена совместимость со сборкой на чистой `CentOS`, без `EPEL`. Для `Fedora` ничего не изменилось.
  * Гайд по пакетированию - https://fedoraproject.org/wiki/User:Bkabrda/EPEL7_Python3
  * Тестовые билды для актуальных `EPEL/Fedora` - https://copr.fedorainfracloud.org/coprs/miushanov/pyaddons-testing/build/843329/