### PR TITLE
spec: enable tests for python36

### DIFF
--- a/python-object-validator.spec
+++ b/python-object-validator.spec
@@ -29,7 +29,7 @@ validate arbitrary Python objects or to support custom validation rules.}
 
 Name:    python-%project_name
 Version: 0.2.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Python object validation module
 
 Group:   Development/Libraries
@@ -139,6 +139,9 @@ make PYTHON=%{__python3_other} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 
 
 %changelog
+* Sun Feb 10 2019 Mikhail Ushanov <gm.mephisto@gmail.com> - 0.2.0-3
+- Enable tests for python36
+
 * Wed Jan 09 2019 Mikhail Ushanov <gm.mephisto@gmail.com> - 0.2.0-2
 - Add python3 package build for EPEL
 

--- a/python-object-validator.spec
+++ b/python-object-validator.spec
@@ -25,12 +25,7 @@ supposed to be used for validation of configuration files represented as JSON
 or for validation of JSON-PRC requests, but it can be easily extended to
 validate arbitrary Python objects or to support custom validation rules.}
 
-# Temporarily disable tests for python3_other
-%if 0%{with python3_other}
-%bcond_with tests
-%else
 %bcond_without tests
-%endif
 
 Name:    python-%project_name
 Version: 0.2.0


### PR DESCRIPTION
В EPEL7 собрали `python36-pytest` (https://bugzilla.redhat.com/show_bug.cgi?id=1664684, https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2019-bbecb2cc93), теперь можно включить unit-тесты для `python3_other`.
Тестовый билд - https://copr.fedorainfracloud.org/coprs/miushanov/pyaddons-testing/build/856887/